### PR TITLE
Remove dummy sortOptions

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -51,14 +51,6 @@ class Plugin extends \craft\base\Plugin
             }
         );
 
-        Event::on(Entry::class, Element::EVENT_REGISTER_SORT_OPTIONS, function(RegisterElementSortOptionsEvent $event) {
-            $event->sortOptions[] = [
-                'label' => '<FieldName>',
-                'orderBy' => 'field_<FieldHandle>',
-                'attribute' => 'field:<FieldID>'
-            ];
-        });
-
         Craft::info(
             'starfield plugin loaded',
             __METHOD__


### PR DESCRIPTION
This could cause the error: Column not found: 1054 Unknown column 'field_<FieldHandle>' in 'order clause'